### PR TITLE
added isUkMobile validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@
 
 A general purpose validation library for Deno.
 
+## Validators
+
+This is the list of current validators
+
+| validator    | description                                          | example      |
+|--------------|------------------------------------------------------|--------------|
+| isEmpty      | check is a given object is empty                     | ""           |
+| isUkMobile   | only valid UK mobile numbers _(exludes Isle of Man)_ | 07100900023  |
+
 ## Running locally
 
 [TODO]

--- a/src/mods.ts
+++ b/src/mods.ts
@@ -7,4 +7,4 @@
 // # -- Date:    22/07/2022
 // # --
 // # -- ---------------------------------------------------------------------------
-export { isEmpty } from "./validation.ts";
+export { isEmpty, isUkMobile } from "./validation.ts";

--- a/src/tests/validation.ts
+++ b/src/tests/validation.ts
@@ -1,4 +1,4 @@
-import { isEmpty } from "../mods.ts";
+import { isEmpty, isUkMobile } from "../mods.ts";
 import { assertEquals } from "https://deno.land/std@0.149.0/testing/asserts.ts";
 
 Deno.test("isEmpty", () => {
@@ -11,3 +11,47 @@ Deno.test("isEmpty", () => {
   assertEquals(isEmpty("Hello World!"), false);
   assertEquals(isEmpty(0), false);
 });
+
+Deno.test("isUkMobile - Phones since January 2017 (071x)", () => {
+  assertEquals(isUkMobile("07100900023"), true);
+});
+Deno.test("isUkMobile - Phones since November 2014 (073x)", () => {
+  assertEquals(isUkMobile("07300900023"), true);
+});
+Deno.test("isUkMobile - Phones since November 2009 (074x)", () => {
+  assertEquals(isUkMobile("07400900023"), true);
+});
+Deno.test("isUkMobile - Vodafone, 02 A (075x)", () => {
+  assertEquals(isUkMobile("07500900023"), true);
+});
+Deno.test("isUkMobile - Vodafone, 02 B (077x)", () => {
+  assertEquals(isUkMobile("07700900023"), true);
+});
+Deno.test("isUkMobile - Vodafone, 02 C (078x)", () => {
+  assertEquals(isUkMobile("07800900023"), true);
+});
+Deno.test("isUkMobile - Orange, EE, one2one (079x)", () => {
+  assertEquals(isUkMobile("07900900023"), true);
+});
+Deno.test("isUkMobile - should not include characters", () => {
+  assertEquals(isUkMobile("071x0900023"), false);
+});
+Deno.test("isUkMobile - should not have space before", () => {
+  assertEquals(isUkMobile(" 07100900023"), false);
+});
+Deno.test("isUkMobile - should not have space after", () => {
+  assertEquals(isUkMobile("07100900023 "), false);
+});
+Deno.test("isUkMobile - should not have space before and after", () => {
+  assertEquals(isUkMobile(" 07100900023 "), false);
+});
+Deno.test("isUkMobile - should not have multiple spaces inbetween", () => {
+  assertEquals(isUkMobile("071009   00023"), false);
+});
+Deno.test("isUkMobile - should not be shorter then 11 digits", () => {
+  assertEquals(isUkMobile("0710090002"), false);
+});
+Deno.test("isUkMobile - should not be longer then 11 digits", () => {
+  assertEquals(isUkMobile("071009000237"), false);
+});
+

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -2,3 +2,10 @@ export const isEmpty = (str: any): boolean => {
   return (String(str).trim() === "" || str?.length === 0 || str === null ||
     str === undefined);
 };
+
+// WARNING: we exclude Isle of Man mobile numbers
+const ukMobileRegex: RegExp = /^07[1,3,4,5,7,8,9]\d{8}$/;
+
+export const isUkMobile = (mobile: string): boolean => {
+    return ukMobileRegex.test(mobile)
+}


### PR DESCRIPTION
This PR adds a new `isUkMobile` validator, this only accepts valid UK mobile numbers, however this excludes mobile numbers from Isle of Man.

We include all the various test conditions to confirm that the validator follows the UK mobile specifications

The specs are detailed below:

| spec       | description                     |
|-------------|---------------------------------|
| 071x       | phones since Jan 2017  |
| 073x       | phones since nov 2014  |
| 074x       | phones since nov 2009  |
| 075x       | phones since may 2007 |
| 077x      |  vodafone, 02                  |
| 078x       | vodafone, 02                 |
| 079x      | EE, Orange, one2one   |  